### PR TITLE
[Feat] 학습 종료뷰 카드 이미지 크기 조절

### DIFF
--- a/Projects/SNurdy/Sources/Feature/TestEnd/TestEndView.swift
+++ b/Projects/SNurdy/Sources/Feature/TestEnd/TestEndView.swift
@@ -25,7 +25,7 @@ struct TestEndView: View {
 
     var body: some View {
         VStack {
-            Spacer(minLength: 140)
+            Spacer()
             
             Text(top)
                 .font(.body)
@@ -34,11 +34,13 @@ struct TestEndView: View {
             Text(bottom)
                 .font(.title)
                 .foregroundStyle(AppColor.grey4)
-                .padding(.bottom, 54)
+                .padding(.bottom, 59)
             
             ZStack {
                 Image("cardImage")
-                    .padding(.leading, 40)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(.horizontal, 55)
                 VStack {
                     Text("오늘 학습한 용어")
                         .font(.body)
@@ -70,5 +72,20 @@ struct TestEndView: View {
         .background(AppColor.bgColor)
         .navigationBarBackButtonHidden(true)
         .ignoresSafeArea()
+    }
+}
+
+import SwiftUI
+
+struct TestEndView_Previews: PreviewProvider {
+    @State static var isStudyInProgress = true
+    @State static var learningType: LearningType = .study
+    
+    static var previews: some View {
+        TestEndView(
+            isStudyInProgress: $isStudyInProgress,
+            index: 4,
+            learningType: $learningType
+        )
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 작업 요약)
예시: [Feat] 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #24 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 학습 종료뷰 카드 이미지 크기 조절

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="스크린샷 2025-07-24 오후 10 44 22" src="https://github.com/user-attachments/assets/7a0ef91e-bbde-4c86-af18-c5d96f03461d" />


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
