### PR TITLE
[Fix] 사전 빈 공간 탭 시 가상 키보드 해제

### DIFF
--- a/Projects/SNurdy/SNurdy.entitlements
+++ b/Projects/SNurdy/SNurdy.entitlements
@@ -5,7 +5,9 @@
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
+	<array>
+		<string>iCloud.org.medical.SNurdy</string>
+	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudKit</string>

--- a/Projects/SNurdy/SNurdy.entitlements
+++ b/Projects/SNurdy/SNurdy.entitlements
@@ -5,9 +5,7 @@
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.org.medical.SNurdy</string>
-	</array>
+	<array/>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudKit</string>

--- a/Projects/SNurdy/Sources/Feature/Dictionary/DictionaryView.swift
+++ b/Projects/SNurdy/Sources/Feature/Dictionary/DictionaryView.swift
@@ -11,10 +11,13 @@ import SwiftUI
 
 struct DictionaryView: View {
     @State private var viewModel: DictionaryViewModel = .init()
+    @FocusState private var isSearchFocused: Bool
+
 
     var body: some View {
         VStack(spacing: 0) {
             DictionaryHeaderView(searchText: $viewModel.searchText)
+                .focused($isSearchFocused)
 
             DictionaryTermListView(viewModel: viewModel)
                 .padding(.bottom, 64)
@@ -27,6 +30,8 @@ struct DictionaryView: View {
             DictionaryDetailView(term: term)
                 .presentationDetents([.height(640)])
                 .presentationDragIndicator(.visible)
+        }.onTapGesture {
+            isSearchFocused = false
         }
     }
 }

--- a/Projects/SNurdy/Sources/Feature/Dictionary/SubView/DictionarySearchBoxView.swift
+++ b/Projects/SNurdy/Sources/Feature/Dictionary/SubView/DictionarySearchBoxView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DictionarySearchBoxView: View {
     @Binding var searchText: String
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         RoundedRectangle(cornerRadius: 13)
@@ -21,6 +22,7 @@ struct DictionarySearchBoxView: View {
                             .font(.caption)
                             .foregroundStyle(AppColor.grey3)
                     )
+                    .focused($isFocused)
                     .foregroundStyle(AppColor.label)
                     .padding(21)
                     Spacer()
@@ -36,6 +38,9 @@ struct DictionarySearchBoxView: View {
             )
             .foregroundStyle(Color.white)
             .frame(height: 50)
+            .onTapGesture {
+                isFocused = true
+            }
     }
 }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 작업 요약)
예시: [Feat] 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #28 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 사전 검색창 눌렀다가 빈 공간 탭 시 가상 키보드 비활성화

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 18.6 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
